### PR TITLE
Accept `onError()` and return `allReady`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,6 @@ await renderToStream(<Page />, options)
 
 - `options.userAgent?: string`: The HTTP User-Agent request header. (Needed for `options.seoStrategy`.)
 - `options.webStream?: boolean`: Use Web Streams instead of Node.js Streams in Node.js. ([Node.js 18 released Web Streams support](https://nodejs.org/en/blog/announcements/v18-release-announce/#web-streams-api-experimental).)
-- `options.onBeforeEnd?: (success: boolean) => void`: Called before the stream ends.
-  The `success` value is usually used for sending different headers depending on the success of `<Suspense>` boundaries.
-  ⚠️
-  This is not implemented yet.
-  Pull Request welcome, or open a new GitHub issue.
 - `options.onBoundaryError?: (err: unknown) => void`: Called when a `<Suspense>` boundary fails. See [Error Handling](#error-handling).
 -  ```ts
    const { streamEnd } = await renderToStream(<Page />)
@@ -174,7 +169,7 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 >
 > This means that errros occuring during the stream are handled by React and there is nothing for you to do on the server-side. That said, you may want to gracefully handle the error on the client-side e.g. with [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary).
 >
-> You can use `options.onBoundaryError()` for error tracking purposes, and `const success = await streamEnd` for sending different headers upon boundary failure.
+> You can use `options.onBoundaryError()` for error tracking purposes.
 
 ### Bonus: `useAsync()`
 

--- a/src/renderToStream.ts
+++ b/src/renderToStream.ts
@@ -148,7 +148,8 @@ async function renderToWebStream(
   const onError = (err: unknown) => {
     didError = true
     firstErr = firstErr || err
-    setTimeout(() => {
+// Hacky solution to workaround https://github.com/facebook/react/issues/24536
+setTimeout(() => {
       if (fatalErr !== err) {
         options.onBoundaryError?.(err)
       }

--- a/src/renderToStream/createPipeWrapper.ts
+++ b/src/renderToStream/createPipeWrapper.ts
@@ -9,7 +9,7 @@ type Pipe = (writable: StreamNodeWritable) => void
 
 async function createPipeWrapper(
   pipeOriginal: Pipe,
-  { debug, onError }: { debug?: boolean; onError: (err: unknown) => void }
+  { debug, onFatalError }: { debug?: boolean; onFatalError: (err: unknown) => void }
 ) {
   const { Writable } = await loadNodeStreamModule()
   const pipeWrapper = createPipeWrapper()
@@ -35,9 +35,9 @@ async function createPipeWrapper(
           writable.end()
           callback()
         },
-        // If we don't define `destroy()`, then Node.js will `process.exit()`
         destroy(err) {
-          onError(err)
+          onFatalError(err)
+          writable.destroy(err ?? undefined)
         }
       })
       bufferParams.writeChunk = (chunk: string) => {

--- a/src/renderToStream/createPipeWrapper.ts
+++ b/src/renderToStream/createPipeWrapper.ts
@@ -9,7 +9,7 @@ type Pipe = (writable: StreamNodeWritable) => void
 
 async function createPipeWrapper(
   pipeOriginal: Pipe,
-  { debug, onFatalError }: { debug?: boolean; onFatalError: (err: unknown) => void }
+  { debug, onReactBug }: { debug?: boolean; onReactBug: (err: unknown) => void }
 ) {
   const { Writable } = await loadNodeStreamModule()
   const { pipeWrapper, streamEnd } = createPipeWrapper()
@@ -39,7 +39,8 @@ async function createPipeWrapper(
           callback()
         },
         destroy(err) {
-          onFatalError(err)
+          // Upon React internal errors (i.e. React bugs), React destroys the stream.
+          if (err) onReactBug(err)
           writable.destroy(err ?? undefined)
           onEnded()
         }

--- a/test/renderToStream.test.tsx
+++ b/test/renderToStream.test.tsx
@@ -6,22 +6,22 @@ import { render } from './render'
 describe('renderToStream()', async () => {
   ;(['node', 'web'] as const).forEach((streamType: 'node' | 'web') => {
     it(`basic - ${streamType} Stream`, async () => {
-      const { data, streamEnded } = await render(<div>hello</div>, { streamType })
-      await streamEnded
+      const { data, streamEnd } = await render(<div>hello</div>, { streamType })
+      await streamEnd
       expect(data.content).toBe('<div>hello</div>')
     })
   })
   ;(['node', 'web'] as const).forEach((streamType: 'node' | 'web') => {
     it(`injectToStream - basic - ${streamType} stream`, async () => {
-      const { data, streamEnded, injectToStream } = await render(<>hi</>, { streamType })
+      const { data, streamEnd, injectToStream } = await render(<>hi</>, { streamType })
       injectToStream('<script type="module" src="/main.js"></script>')
-      await streamEnded
+      await streamEnd
       expect(data.content).toBe('hi<!-- --><script type="module" src="/main.js"></script>')
     })
   })
   ;(['node', 'web'] as const).forEach((streamType: 'node' | 'web') => {
     it(`injectToStream - useAsync() - ${streamType} stream`, async () => {
-      const { data, streamEnded, injectToStream } = await render(<Page />, { streamType })
+      const { data, streamEnd, injectToStream } = await render(<Page />, { streamType })
       injectToStream('<script type="module" src="/main.js"></script>')
 
       let timeoutResolved = false
@@ -31,7 +31,7 @@ describe('renderToStream()', async () => {
       }, 5)
 
       expect(timeoutResolved).toBe(false)
-      await streamEnded
+      await streamEnd
       expect(timeoutResolved).toBe(true)
 
       try {


### PR DESCRIPTION
I'm not sure that the behavior of `allReady` is identical between implementations, but I did my best in reading React code to match the behavior :D