### PR TITLE
useAsync/useSSRData with dependencies

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+import React from "react";
+
+type UseEffectParams = Parameters<typeof React.useEffect>;
+export type DependencyList = UseEffectParams[1];

--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -1,10 +1,13 @@
+
+
 export { useAsync }
 
 import { useId } from 'react'
 import { useSsrData } from './useSsrData'
+import { DependencyList } from "./types";
 
-function useAsync<T>(asyncFn: () => Promise<T>): T {
+function useAsync<T>(asyncFn: () => Promise<T>, deps?: DependencyList): T {
   const id: string = useId()
   // TODO: throw new Error('Only one `useAsync()` hook can be used per component')
-  return useSsrData(id, asyncFn)
+  return useSsrData(id, asyncFn, deps)
 }

--- a/src/useSsrData.ts
+++ b/src/useSsrData.ts
@@ -1,3 +1,5 @@
+
+
 export { SsrDataProvider }
 export { useSsrData }
 
@@ -5,54 +7,75 @@ import React, { useContext } from 'react'
 import { useStream } from './useStream'
 import { assert, isClientSide, isServerSide } from './utils'
 import { parse, stringify } from '@brillout/json-s'
+import { DependencyList } from "./types";
 
 const Ctx = React.createContext<Data>(undefined as any)
 
 type Data = Record<string, Entry>
 type Entry =
-  | { state: 'pending'; promise: Promise<unknown> }
-  | { state: 'error'; error: unknown }
-  | { state: 'done'; value: unknown }
+  | { state: "pending"; promise: Promise<unknown>; deps?: DependencyList }
+  | { state: "error"; error: unknown }
+  | { state: "done"; value: unknown; deps?: DependencyList };
 
 function SsrDataProvider({ children }: { children: React.ReactNode }) {
   const data = {}
   return React.createElement(Ctx.Provider, { value: data }, children)
 }
 
-type SsrData = { key: string; value: unknown }
+type SsrData = { key: string; value: unknown; deps?: DependencyList };
 const className = 'react-streaming_ssr-data'
 function getHtmlChunk(entry: SsrData): string {
   const ssrData = [entry]
-  const htmlChunk = `<script class="${className}" type="application/json">${stringify(ssrData)}</script>`
-  return htmlChunk
+  return `<script class="${className}" type="application/json">${stringify(ssrData)}</script>`
 }
 
-function getSsrData(key: string): { isAvailable: true; value: unknown } | { isAvailable: false } {
-  const els = Array.from(window.document.querySelectorAll(`.${className}`))
+function getJsonScriptElement(
+  key: string
+): { el: Element; entry: SsrData } | undefined {
+  const els = Array.from(window.document.querySelectorAll(`.${className}`));
   for (const el of els) {
-    assert(el.textContent)
-    const data = parse(el.textContent) as SsrData[]
+    assert(el.textContent);
+    const data = parse(el.textContent) as SsrData[];
     for (const entry of data) {
-      assert(typeof entry.key === 'string')
+      assert(typeof entry.key === "string");
       if (entry.key === key) {
-        const { value } = entry
-        return { isAvailable: true, value }
+        return { el, entry };
       }
     }
   }
-  return { isAvailable: false }
+  return;
 }
 
-function useSsrData<T>(key: string, asyncFn: () => Promise<T>): T {
+function getSsrData(
+  key: string
+):
+  | { isAvailable: true; value: unknown; el: Element; deps?: DependencyList }
+  | { isAvailable: false } {
+  const { el, entry } = getJsonScriptElement(key) || {};
+
+  if (el && entry) {
+    const { value, deps } = entry;
+    return { isAvailable: true, value, deps, el };
+  }
+  return { isAvailable: false };
+}
+
+function useSsrData<T>(key: string, asyncFn: () => Promise<T>, deps?: DependencyList): T {
+  const data = useContext(Ctx);
+  let hasChanged = false;
   if (isClientSide()) {
     const ssrData = getSsrData(key)
     if (ssrData.isAvailable) {
-      return ssrData.value as T
+      if (deps) {
+        hasChanged = deps.some(
+          (d, index) => !Object.is(d, ssrData?.deps[index])
+        );
+      }
+      if (!hasChanged) return ssrData.value as T;
     }
   }
-  const data = useContext(Ctx)
   let entry = data[key]
-  if (!entry) {
+  if (!entry || hasChanged) {
     const streamUtils = useStream()
     const promise = (async () => {
       let value: unknown
@@ -67,6 +90,13 @@ function useSsrData<T>(key: string, asyncFn: () => Promise<T>): T {
       if (isServerSide()) {
         assert(streamUtils)
         streamUtils.injectToStream(getHtmlChunk({ key, value }))
+      } else {
+        const { el } = getJsonScriptElement(key) || {};
+        if (el) {
+          el.textContent = stringify([
+          { key, value: entry.value, deps },
+        ]);
+        }
       }
     })()
     entry = data[key] = { state: 'pending', promise }


### PR DESCRIPTION
That PR allows to provide dependencies to `useAsync/useSSRData` so that the promise is re-executed whenever there's a change.