### PR TITLE
Add browser entry to server exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "./server": {
       "node": "./dist/cjs/server/index.js",
       "worker": "./dist/esm/server/index.js",
-      "deno": "./dist/esm/server/index.js"
+      "deno": "./dist/esm/server/index.js",
+      "browser": "./dist/esm/server/hooks.js"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "node": "./dist/cjs/server/index.js",
       "worker": "./dist/esm/server/index.js",
       "deno": "./dist/esm/server/index.js",
-      "browser": "./dist/esm/server/hooks.js"
+      "browser": "./dist/esm/server/client-poison-pill.js"
     }
   },
   "devDependencies": {

--- a/src/server/client-poison-pill.ts
+++ b/src/server/client-poison-pill.ts
@@ -1,0 +1,6 @@
+import { assertUsage } from './utils'
+
+assertUsage(
+  false,
+  "`import { something } from 'react-streaming/server'` in client-side code is forbidden: the module react-streaming/server should never be loaded on the client-side"
+)


### PR DESCRIPTION
As discussed in #26, this PR adds a `browser` export to `react-streaming/server` so I can load  `react-streaming` through vite's SSR utilities.

The codebase has a bunch of checks to ensure that `react-streaming/server` isn't included in the browser and they are still functioning as expected. I tested that this one line is all that's required to make vite happy by modifying my locally installed version of `react-streaming`