### PR TITLE
impl: Add abort pass back for node pipes and options passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ await renderToStream(<Page />, options)
     ```
 
 - `options.userAgent?: string`: The HTTP User-Agent request header. (Needed for `options.seoStrategy`.)
-- `options.webStream?: boolean`: Use Web Streams instead of Node.js Streams in Node.js. ([Node.js 18 released Web Streams support](https://nodejs.org/en/blog/announcements/v18-release-announce/#web-streams-api-experimental).)
+- `options.webStream?: boolean`: In Node.js, use a Web Stream instead of a Node.js Stream. ([Node.js 18 released Web Streams support](https://nodejs.org/en/blog/announcements/v18-release-announce/#web-streams-api-experimental).)
+- `options.streamOptions`: Options passed to React's [renderToReadableStream()](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters) and [`renderToPipeableStream()`](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters). Use this to pass `nonce`, bootstrap scripts, etc. It excludes error handling options, use [Error Handling](#error-handling) instead.
 - `options.onBoundaryError?: (err: unknown) => void`: Called when a `<Suspense>` boundary fails. See [Error Handling](#error-handling).
 -  ```tsx
    const { streamEnd } = await renderToStream(<Page />)
@@ -141,7 +142,6 @@ await renderToStream(<Page />, options)
    Note that `streamEnd` never rejects.
    > ⚠️
    > Read [Error Handling](#error-handling) before using `streamEnd`. In particular, do not use `success` to change the behavior of your app/stream (because React automatically takes care of gracefully handling `<Suspense>` failures).
-- `options.streamOptions?: ReactStreamOptions`: Options to passthrough to Reacts `renderToReadableStream` or `renderToPipeableStream` depending which stream type you are using. This allows for passing in things like `nonce` or other bootstrap scripts etc, it excludes error handling options use [Error Handling](#error-handling). See [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters) and [renderToReadableStream](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters) for available options.
 
 ### Error Handling
 
@@ -168,11 +168,15 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 >
 > You can use `options.onBoundaryError()` for error tracking purposes.
 
-#### Aborting server rendering 
+#### Aborting server rendering
 
 You may want to set a timeout for React rendering as mentioned [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [here](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
 
-For `renderToPipeableStream` we return `abort` as part of `Result` from `renderToStream` and for `renderToReadableStream` you can use `options.streamOptions` which accepts the `signal` parameter. These then work as per the React docs linked. 
+When `react-streaming` uses a:
+ - Node.js Stream then you can use the `abort()` function (`const { abort } = await renderToStream(<Page />)`.
+ - Web Stream then you can use the `streamOptions.signal` parameter (`await renderToStream(<Page />, { streamOptions })`).
+
+The `abort()` function and the `signal` parameter work as per the linked React docs.
 
 ### `useAsync()`
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ await renderToStream(<Page />, options)
    Note that `streamEnd` never rejects.
    > ⚠️
    > Read [Error Handling](#error-handling) before using `streamEnd`. In particular, do not use `success` to change the behavior of your app/stream (because React automatically takes care of gracefully handling `<Suspense>` failures).
-
+- `options.streamOptions?: ReactStreamOptions`: Options to passthrough to Reacts `renderToReadableStream` or `renderToPipeableStream` depending which stream type you are using. This allow for passing in things like `nonce` or other bootstrap scripts etc, it excludes error handling options use [Error Handling](#error-handling). See [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters) and [renderToReadableStream](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters).
 
 ### Error Handling
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Solution: `react-streaming`.
    import { renderToStream } from 'react-streaming/server'
    const {
      pipe, // Defined if running in Node.js, otherwise `null`
-     abort, // Defined if running in Node.js, otherwise `null`
      readable // Defined if running on the Edge (.e.g. Coudflare Workers), otherwise `null`
    } = await renderToStream(<Page />)
    ```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Solution: `react-streaming`.
    import { renderToStream } from 'react-streaming/server'
    const {
      pipe, // Defined if running in Node.js, otherwise `null`
+     abort, // Defined if running in Node.js, otherwise `null`
      readable // Defined if running on the Edge (.e.g. Coudflare Workers), otherwise `null`
    } = await renderToStream(<Page />)
    ```
@@ -163,9 +164,15 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 > Instead of emiting a stream error, React swallows the error on the server-side and retries to resolve the `<Suspense>` boundary on the client-side.
 > If the `<Suspense>` fails again on the client-side, then the client-side throws the error.
 >
-> This means that errros occuring during the stream are handled by React and there is nothing for you to do on the server-side. That said, you may want to gracefully handle the error on the client-side e.g. with [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary).
+> This means that errors occuring during the stream are handled by React and there is nothing for you to do on the server-side. That said, you may want to gracefully handle the error on the client-side e.g. with [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary).
 >
 > You can use `options.onBoundaryError()` for error tracking purposes.
+
+#### Aborting server rendering 
+
+You may want to set a timeout for React rendering as mentioned [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [here](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
+
+For `renderToPipeableStream` we return `abort` as part of `Result` from `renderToStream` and for `renderToReadableStream` you can use `options.streamOptions` which accepts the `signal` parameter. These then work as per the React docs linked. 
 
 ### `useAsync()`
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ await renderToStream(<Page />, options)
    Note that `streamEnd` never rejects.
    > ⚠️
    > Read [Error Handling](#error-handling) before using `streamEnd`. In particular, do not use `success` to change the behavior of your app/stream (because React automatically takes care of gracefully handling `<Suspense>` failures).
-- `options.streamOptions?: ReactStreamOptions`: Options to passthrough to Reacts `renderToReadableStream` or `renderToPipeableStream` depending which stream type you are using. This allow for passing in things like `nonce` or other bootstrap scripts etc, it excludes error handling options use [Error Handling](#error-handling). See [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters) and [renderToReadableStream](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters).
+- `options.streamOptions?: ReactStreamOptions`: Options to passthrough to Reacts `renderToReadableStream` or `renderToPipeableStream` depending which stream type you are using. This allows for passing in things like `nonce` or other bootstrap scripts etc, it excludes error handling options use [Error Handling](#error-handling). See [renderToPipeableStream](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters) and [renderToReadableStream](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters) for available options.
 
 ### Error Handling
 

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -7,7 +7,9 @@ import React from 'react'
 import ReactDOMServer, { version as reactDomVersion } from 'react-dom/server'
 import type {
   renderToPipeableStream as RenderToPipeableStream,
-  renderToReadableStream as RenderToReadableStream
+  RenderToPipeableStreamOptions,
+  renderToReadableStream as RenderToReadableStream,
+  RenderToReadableStreamOptions
 } from 'react-dom/server'
 import { SuspenseData } from './useAsync/useSuspenseData'
 import { StreamProvider } from './useStream'
@@ -30,6 +32,8 @@ type Options = {
   seoStrategy?: SeoStrategy
   userAgent?: string
   onBoundaryError?: (err: unknown) => void
+  webStreamOptions?: Omit<RenderToReadableStreamOptions, 'onError'>
+  nodePipeOptions?: Omit<RenderToPipeableStreamOptions, 'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'>
   // Are these two options still needed? I think we can now remove them.
   //  - options.renderToReadableStream used to be needed by https://github.com/brillout/react-streaming/blob/43941f65e84e88a05801a93723df0e38687df872/test/render.tsx#L51 but that isnt' the case anymore.
   //  - option.renderToPipeableStream was introduced by https://github.com/brillout/react-streaming/commit/9f0403d7b738e59ddc3dcaa27f0e3fd33a8f5895 but I don't remember why. Do we still it?
@@ -41,9 +45,11 @@ type Result = (
   | {
       pipe: Pipe
       readable: null
+      abort: () => void;
     }
   | {
       pipe: null
+      abort: null;
       readable: ReadableStream
     }
 ) & {

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -26,7 +26,7 @@ const globalObject = getGlobalObject('renderToStream.ts', {
 
 assertReact()
 
-export type ReactStreamOptions = Omit<
+export type StreamOptions = Omit<
   RenderToPipeableStreamOptions,
   'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'
 > |
@@ -38,7 +38,7 @@ type Options = {
   seoStrategy?: SeoStrategy
   userAgent?: string
   onBoundaryError?: (err: unknown) => void
-  streamOptions?: ReactStreamOptions
+  streamOptions?: StreamOptions
   // Are these two options still needed? I think we can now remove them.
   //  - options.renderToReadableStream used to be needed by https://github.com/brillout/react-streaming/blob/43941f65e84e88a05801a93723df0e38687df872/test/render.tsx#L51 but that isnt' the case anymore.
   //  - option.renderToPipeableStream was introduced by https://github.com/brillout/react-streaming/commit/9f0403d7b738e59ddc3dcaa27f0e3fd33a8f5895 but I don't remember why. Do we still it?

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -26,14 +26,19 @@ const globalObject = getGlobalObject('renderToStream.ts', {
 
 assertReact()
 
+export type ReactStreamOptions = Omit<
+  RenderToPipeableStreamOptions,
+  'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'
+> &
+  Omit<RenderToReadableStreamOptions, 'onError'>
+
 type Options = {
   webStream?: boolean
   disable?: boolean
   seoStrategy?: SeoStrategy
   userAgent?: string
   onBoundaryError?: (err: unknown) => void
-  webStreamOptions?: Omit<RenderToReadableStreamOptions, 'onError'>
-  nodePipeOptions?: Omit<RenderToPipeableStreamOptions, 'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'>
+  streamOptions?: ReactStreamOptions
   // Are these two options still needed? I think we can now remove them.
   //  - options.renderToReadableStream used to be needed by https://github.com/brillout/react-streaming/blob/43941f65e84e88a05801a93723df0e38687df872/test/render.tsx#L51 but that isnt' the case anymore.
   //  - option.renderToPipeableStream was introduced by https://github.com/brillout/react-streaming/commit/9f0403d7b738e59ddc3dcaa27f0e3fd33a8f5895 but I don't remember why. Do we still it?
@@ -45,11 +50,11 @@ type Result = (
   | {
       pipe: Pipe
       readable: null
-      abort: () => void;
+      abort: () => void
     }
   | {
       pipe: null
-      abort: null;
+      abort: null
       readable: ReadableStream
     }
 ) & {

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -29,7 +29,7 @@ assertReact()
 export type ReactStreamOptions = Omit<
   RenderToPipeableStreamOptions,
   'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'
-> &
+> |
   Omit<RenderToReadableStreamOptions, 'onError'>
 
 type Options = {

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -3,7 +3,7 @@ export { renderToNodeStream }
 import React from 'react'
 // @ts-expect-error types export missing
 import { renderToPipeableStream as renderToPipeableStream_ } from 'react-dom/server.node'
-import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
+import type { RenderToPipeableStreamOptions, renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
 import { createPipeWrapper } from './createPipeWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
 
@@ -13,6 +13,7 @@ async function renderToNodeStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
+    nodePipeOptions?: Omit<RenderToPipeableStreamOptions, 'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'>
     renderToPipeableStream?: typeof renderToPipeableStream__
   }
 ) {
@@ -47,7 +48,8 @@ async function renderToNodeStream(
   if (!options.renderToPipeableStream) {
     assertReactImport(renderToPipeableStream, 'renderToPipeableStream')
   }
-  const { pipe: pipeOriginal } = renderToPipeableStream(element, {
+  const { pipe: pipeOriginal, abort } = renderToPipeableStream(element, {
+    ...options.nodePipeOptions,
     onShellReady() {
       debugFlow('[react] onShellReady()')
       onShellReady()
@@ -80,6 +82,7 @@ async function renderToNodeStream(
   promiseResolved = true
   return {
     pipe: pipeForUser,
+    abort,
     readable: null,
     streamEnd: wrapStreamEnd(streamEnd, didError),
     injectToStream

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -6,7 +6,7 @@ import { renderToPipeableStream as renderToPipeableStream_ } from 'react-dom/ser
 import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
 import { createPipeWrapper } from './createPipeWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
-import type { ReactStreamOptions } from '../renderToStream'
+import type { StreamOptions } from '../renderToStream'
 
 async function renderToNodeStream(
   element: React.ReactNode,
@@ -14,7 +14,7 @@ async function renderToNodeStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
-    streamOptions?: ReactStreamOptions
+    streamOptions?: StreamOptions
     renderToPipeableStream?: typeof renderToPipeableStream__
   }
 ) {

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -3,9 +3,10 @@ export { renderToNodeStream }
 import React from 'react'
 // @ts-expect-error types export missing
 import { renderToPipeableStream as renderToPipeableStream_ } from 'react-dom/server.node'
-import type { RenderToPipeableStreamOptions, renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
+import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
 import { createPipeWrapper } from './createPipeWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
+import type { ReactStreamOptions } from '../renderToStream'
 
 async function renderToNodeStream(
   element: React.ReactNode,
@@ -13,7 +14,7 @@ async function renderToNodeStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
-    nodePipeOptions?: Omit<RenderToPipeableStreamOptions, 'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'>
+    streamOptions?: ReactStreamOptions
     renderToPipeableStream?: typeof renderToPipeableStream__
   }
 ) {
@@ -49,7 +50,7 @@ async function renderToNodeStream(
     assertReactImport(renderToPipeableStream, 'renderToPipeableStream')
   }
   const { pipe: pipeOriginal, abort } = renderToPipeableStream(element, {
-    ...options.nodePipeOptions,
+    ...options.streamOptions,
     onShellReady() {
       debugFlow('[react] onShellReady()')
       onShellReady()

--- a/src/server/renderToStream/renderToWebStream.ts
+++ b/src/server/renderToStream/renderToWebStream.ts
@@ -3,7 +3,7 @@ export { renderToWebStream }
 import React from 'react'
 // @ts-expect-error types export missing
 import { renderToReadableStream as renderToReadableStream_ } from 'react-dom/server.browser'
-import type { renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
+import type { RenderToReadableStreamOptions, renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
 import { createReadableWrapper } from './createReadableWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
 
@@ -13,6 +13,7 @@ async function renderToWebStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
+    webStreamOptions?: Omit<RenderToReadableStreamOptions, 'onError'>
     renderToReadableStream?: typeof renderToReadableStream__
   }
 ) {
@@ -36,7 +37,7 @@ async function renderToWebStream(
   if (!options.renderToReadableStream) {
     assertReactImport(renderToReadableStream, 'renderToReadableStream')
   }
-  const readableOriginal = await renderToReadableStream(element, { onError })
+  const readableOriginal = await renderToReadableStream(element, { onError, ...options.webStreamOptions })
   const { allReady } = readableOriginal
   let promiseResolved = false
   // Upon React internal errors (i.e. React bugs), React rejects `allReady`.
@@ -59,6 +60,7 @@ async function renderToWebStream(
   return {
     readable: readableForUser,
     pipe: null,
+    abort: null,
     streamEnd: wrapStreamEnd(streamEnd, didError),
     injectToStream
   }

--- a/src/server/renderToStream/renderToWebStream.ts
+++ b/src/server/renderToStream/renderToWebStream.ts
@@ -3,9 +3,10 @@ export { renderToWebStream }
 import React from 'react'
 // @ts-expect-error types export missing
 import { renderToReadableStream as renderToReadableStream_ } from 'react-dom/server.browser'
-import type { RenderToReadableStreamOptions, renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
+import type { renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
 import { createReadableWrapper } from './createReadableWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
+import type { ReactStreamOptions } from '../renderToStream'
 
 async function renderToWebStream(
   element: React.ReactNode,
@@ -13,7 +14,7 @@ async function renderToWebStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
-    webStreamOptions?: Omit<RenderToReadableStreamOptions, 'onError'>
+    streamOptions?: ReactStreamOptions
     renderToReadableStream?: typeof renderToReadableStream__
   }
 ) {
@@ -37,7 +38,7 @@ async function renderToWebStream(
   if (!options.renderToReadableStream) {
     assertReactImport(renderToReadableStream, 'renderToReadableStream')
   }
-  const readableOriginal = await renderToReadableStream(element, { onError, ...options.webStreamOptions })
+  const readableOriginal = await renderToReadableStream(element, { onError, ...options.streamOptions })
   const { allReady } = readableOriginal
   let promiseResolved = false
   // Upon React internal errors (i.e. React bugs), React rejects `allReady`.

--- a/src/server/renderToStream/renderToWebStream.ts
+++ b/src/server/renderToStream/renderToWebStream.ts
@@ -6,7 +6,7 @@ import { renderToReadableStream as renderToReadableStream_ } from 'react-dom/ser
 import type { renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
 import { createReadableWrapper } from './createReadableWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
-import type { ReactStreamOptions } from '../renderToStream'
+import type { StreamOptions } from '../renderToStream'
 
 async function renderToWebStream(
   element: React.ReactNode,
@@ -14,7 +14,7 @@ async function renderToWebStream(
   options: {
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
-    streamOptions?: ReactStreamOptions
+    streamOptions?: StreamOptions
     renderToReadableStream?: typeof renderToReadableStream__
   }
 ) {


### PR DESCRIPTION
Quick go at #33 

For node pipes added abort to the result, which lets client implement https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering

For both, added passthrough options excluding the used options by the stream wrappers. 