### PR TITLE
impl: Add timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 
 After a default [timeout](#options) of 20 seconds `react-streaming` aborts the rendering stream, as recommended by React [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [there](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
 
-When the timeout is reached `react-streaming` ends the stream and tells React to stop rendering. Note that there isn't any error thrown: React merely stops server-side rendering and continues on the client-side, see explanation at [Error Handling](#error-handling).
+When the timeout is reached `react-streaming` ends the stream and tells React to stop rendering. Note that there isn't any thrown error: React merely stops server-side rendering and continues on the client-side, see explanation at [Error Handling](#error-handling).
 
 You can also manually abort:
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ await renderToStream(<Page />, options)
 - `options.userAgent?: string`: The HTTP User-Agent request header. (Needed for `options.seoStrategy`.)
 - `options.webStream?: boolean`: In Node.js, use a Web Stream instead of a Node.js Stream. ([Node.js 18 released Web Streams support](https://nodejs.org/en/blog/announcements/v18-release-announce/#web-streams-api-experimental).)
 - `options.streamOptions`: Options passed to React's [`renderToReadableStream()`](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters) and [`renderToPipeableStream()`](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters). Use this to pass `nonce`, bootstrap scripts, etc. It excludes error handling options, use [Error Handling](#error-handling) instead.
-- `options.timeout?: number`: A timeout used to abort Reacts rendering, this does not error but tells React to stop server rendering and continue on client. Defaults to 20s. 
-- `options.onTimeout?: () => void`: A callback when the timeout is reached 
+- `options.timeout?: number | null` (seconds): Timeout after which the rendering stream is aborted, see [Abort](#abort). Defaults to 20 seconds. Set to `null` to disable automatic timeout (we recommend to then implement a manual timeout as explained at [Abort](#abort)).
+- `options.onTimeout?: () => void`: Callback when the timeout is reached.
 - `options.onBoundaryError?: (err: unknown) => void`: Called when a `<Suspense>` boundary fails. See [Error Handling](#error-handling).
 -  ```tsx
    const { streamEnd } = await renderToStream(<Page />)
@@ -169,17 +169,17 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 >
 > You can use `options.onBoundaryError()` for error tracking purposes.
 
-#### Aborting server rendering
+#### Abort
 
-You may want to set a timeout for React rendering as mentioned [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [here](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
+After a default [timeout](#options) of 20 seconds `react-streaming` aborts the rendering stream, as recommended by React [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [there](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
 
-To add a timeout use `options.timeout`, this will abort rendering for you. For logging etc, you can use `options.onTimeout`.
+When the timeout is reached `react-streaming` ends the stream and tells React to stop rendering. Note that there isn't any error thrown: React merely stops server-side rendering and continues on the client-side, see explanation at [Error Handling](#error-handling).
 
-You can also manually abort if a simple timeout isn't enough:
+You can also manually abort:
 
 ```tsx
- const { abort } = await renderToStream(<Page />)
- abort()
+const { abort } = await renderToStream(<Page />, { timeout: null })
+abort()
 ```
 
 ### `useAsync()`

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ await renderToStream(<Page />, options)
 - `options.userAgent?: string`: The HTTP User-Agent request header. (Needed for `options.seoStrategy`.)
 - `options.webStream?: boolean`: In Node.js, use a Web Stream instead of a Node.js Stream. ([Node.js 18 released Web Streams support](https://nodejs.org/en/blog/announcements/v18-release-announce/#web-streams-api-experimental).)
 - `options.streamOptions`: Options passed to React's [`renderToReadableStream()`](https://react.dev/reference/react-dom/server/renderToReadableStream#parameters) and [`renderToPipeableStream()`](https://react.dev/reference/react-dom/server/renderToPipeableStream#parameters). Use this to pass `nonce`, bootstrap scripts, etc. It excludes error handling options, use [Error Handling](#error-handling) instead.
+- `options.timeout?: number`: A timeout used to abort Reacts rendering, this does not error but tells React to stop server rendering and continue on client. Defaults to 20s. 
+- `options.onTimeout?: () => void`: A callback when the timeout is reached 
 - `options.onBoundaryError?: (err: unknown) => void`: Called when a `<Suspense>` boundary fails. See [Error Handling](#error-handling).
 -  ```tsx
    const { streamEnd } = await renderToStream(<Page />)
@@ -171,11 +173,14 @@ The stream returned by `await renderToStream()` doesn't emit errors.
 
 You may want to set a timeout for React rendering as mentioned [here](https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering) and [here](https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering).
 
-When `react-streaming` uses a:
- - Node.js Stream then you can use the `abort()` function (`const { abort } = await renderToStream(<Page />)`.
- - Web Stream then you can use the `streamOptions.signal` parameter (`await renderToStream(<Page />, { streamOptions })`).
+To add a timeout use `options.timeout`, this will abort rendering for you. For logging etc, you can use `options.onTimeout`.
 
-The `abort()` function and the `signal` parameter work as per the linked React docs.
+You can also manually abort if a simple timeout isn't enough:
+
+```tsx
+ const { abort } = await renderToStream(<Page />)
+ abort()
+```
 
 ### `useAsync()`
 

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -37,7 +37,7 @@ type Options = {
   userAgent?: string
   onBoundaryError?: (err: unknown) => void
   streamOptions?: StreamOptions
-  timeout?: number
+  timeout?: number | null
   onTimeout?: () => void
   // Are these two options still needed? I think we can now remove them.
   //  - options.renderToReadableStream used to be needed by https://github.com/brillout/react-streaming/blob/43941f65e84e88a05801a93723df0e38687df872/test/render.tsx#L51 but that isnt' the case anymore.

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -30,7 +30,7 @@ export type StreamOptions = Omit<
   RenderToPipeableStreamOptions,
   'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'
 > |
-  Omit<RenderToReadableStreamOptions, 'onError'>
+  Omit<RenderToReadableStreamOptions, 'onError' | 'signal'>
 
 type Options = {
   webStream?: boolean
@@ -39,6 +39,8 @@ type Options = {
   userAgent?: string
   onBoundaryError?: (err: unknown) => void
   streamOptions?: StreamOptions
+  timeout?: number
+  onTimeout?: () => void
   // Are these two options still needed? I think we can now remove them.
   //  - options.renderToReadableStream used to be needed by https://github.com/brillout/react-streaming/blob/43941f65e84e88a05801a93723df0e38687df872/test/render.tsx#L51 but that isnt' the case anymore.
   //  - option.renderToPipeableStream was introduced by https://github.com/brillout/react-streaming/commit/9f0403d7b738e59ddc3dcaa27f0e3fd33a8f5895 but I don't remember why. Do we still it?
@@ -54,7 +56,7 @@ type Result = (
     }
   | {
       pipe: null
-      abort: null
+      abort: () => void
       readable: ReadableStream
     }
 ) & {

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -26,11 +26,9 @@ const globalObject = getGlobalObject('renderToStream.ts', {
 
 assertReact()
 
-export type StreamOptions = Omit<
-  RenderToPipeableStreamOptions,
-  'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'
-> |
-  Omit<RenderToReadableStreamOptions, 'onError' | 'signal'>
+export type StreamOptions =
+  | Omit<RenderToPipeableStreamOptions, 'onShellReady' | 'onShellError' | 'onError' | 'onAllReady'>
+  | Omit<RenderToReadableStreamOptions, 'onError' | 'signal'>
 
 type Options = {
   webStream?: boolean

--- a/src/server/renderToStream.ts
+++ b/src/server/renderToStream.ts
@@ -50,17 +50,16 @@ type Result = (
   | {
       pipe: Pipe
       readable: null
-      abort: () => void
     }
   | {
       pipe: null
-      abort: () => void
       readable: ReadableStream
     }
 ) & {
   streamEnd: Promise<boolean>
   disabled: boolean
   injectToStream: (chunk: unknown) => void
+  abort: () => void
 }
 
 const globalConfig: { disable: boolean } = ((globalThis as any).__react_streaming = (globalThis as any)

--- a/src/server/renderToStream/constants.ts
+++ b/src/server/renderToStream/constants.ts
@@ -1,0 +1,2 @@
+// The default timeout for when we abort react rendering
+export const DEFAULT_TIMEOUT = 20000;

--- a/src/server/renderToStream/constants.ts
+++ b/src/server/renderToStream/constants.ts
@@ -1,2 +1,0 @@
-// The default timeout for when we abort react rendering
-export const DEFAULT_TIMEOUT = 20000;

--- a/src/server/renderToStream/createReadableWrapper.ts
+++ b/src/server/renderToStream/createReadableWrapper.ts
@@ -6,7 +6,7 @@ import { createBuffer, StreamOperations } from './createBuffer'
 // `readableForUser` is the readable stream we give to the user (the wrapper)
 // Essentially: what React writes to `readableFromReact` is forwarded to `readableForUser`
 
-function createReadableWrapper(readableFromReact: ReadableStream) {
+function createReadableWrapper(readableFromReact: ReadableStream, { stopTimeout }: { stopTimeout?: () => void }) {
   const streamOperations: StreamOperations = {
     operations: null
   }
@@ -49,6 +49,8 @@ function createReadableWrapper(readableFromReact: ReadableStream) {
       onBeforeWrite(value)
       streamOperations.operations.writeChunk(value)
     }
+
+    stopTimeout?.()
 
     // Collect `injectToStream()` calls stuck in an async call
     setTimeout(() => {

--- a/src/server/renderToStream/misc.ts
+++ b/src/server/renderToStream/misc.ts
@@ -23,5 +23,22 @@ export function wrapStreamEnd(streamEnd: Promise<void>, didError: boolean): Prom
   )
 }
 
-// The default timeout for when we abort the rendering stream
-export const DEFAULT_TIMEOUT = 20000
+export function startTimeout(
+  abortFn: () => void,
+  options: { timeout?: number | null; onTimeout?: () => void }
+): undefined | (() => void) {
+  let stopTimeout: undefined | (() => void)
+  if (options.timeout !== null) {
+    const t = setTimeout(
+      () => {
+        abortFn()
+        options.onTimeout?.()
+      },
+      options.timeout ?? 20 * 1000
+    )
+    stopTimeout = () => {
+      clearTimeout(t)
+    }
+  }
+  return stopTimeout
+}

--- a/src/server/renderToStream/misc.ts
+++ b/src/server/renderToStream/misc.ts
@@ -34,7 +34,7 @@ export function startTimeout(
         abortFn()
         options.onTimeout?.()
       },
-      options.timeout ?? 20 * 1000
+      (options.timeout ?? 20) * 1000
     )
     stopTimeout = () => {
       clearTimeout(t)

--- a/src/server/renderToStream/misc.ts
+++ b/src/server/renderToStream/misc.ts
@@ -22,3 +22,6 @@ export function wrapStreamEnd(streamEnd: Promise<void>, didError: boolean): Prom
       .then(() => !didError)
   )
 }
+
+// The default timeout for when we abort the rendering stream
+export const DEFAULT_TIMEOUT = 20000

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -65,14 +65,19 @@ async function renderToNodeStream(
     onShellError: onError,
     onError
   })
+  let stopTimeout: undefined | (() => void)
   if (options.timeout !== null) {
-    setTimeout(() => {
+    const t = setTimeout(() => {
       abort()
       options.onTimeout?.()
     }, options.timeout ?? DEFAULT_TIMEOUT)
+    stopTimeout = () => {
+      clearTimeout(t)
+    }
   }
   let promiseResolved = false
   const { pipeForUser, injectToStream, streamEnd } = await createPipeWrapper(pipeOriginal, {
+    stopTimeout,
     onReactBug(err) {
       debugFlow('react bug')
       didError = true

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -7,6 +7,7 @@ import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-d
 import { createPipeWrapper } from './createPipeWrapper'
 import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
 import type { StreamOptions } from '../renderToStream'
+import { DEFAULT_TIMEOUT } from './constants'
 
 async function renderToNodeStream(
   element: React.ReactNode,
@@ -15,6 +16,8 @@ async function renderToNodeStream(
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
     streamOptions?: StreamOptions
+    timeout?: number
+    onTimeout?: () => void
     renderToPipeableStream?: typeof renderToPipeableStream__
   }
 ) {
@@ -63,6 +66,10 @@ async function renderToNodeStream(
     onShellError: onError,
     onError
   })
+  setTimeout(() => {
+    abort()
+    options.onTimeout && options.onTimeout()
+  }, options.timeout ?? DEFAULT_TIMEOUT)
   let promiseResolved = false
   const { pipeForUser, injectToStream, streamEnd } = await createPipeWrapper(pipeOriginal, {
     onReactBug(err) {

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -5,9 +5,8 @@ import React from 'react'
 import { renderToPipeableStream as renderToPipeableStream_ } from 'react-dom/server.node'
 import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
 import { createPipeWrapper } from './createPipeWrapper'
-import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
+import { afterReactBugCatch, assertReactImport, debugFlow, DEFAULT_TIMEOUT, wrapStreamEnd } from './misc'
 import type { StreamOptions } from '../renderToStream'
-import { DEFAULT_TIMEOUT } from './constants'
 
 async function renderToNodeStream(
   element: React.ReactNode,
@@ -68,7 +67,7 @@ async function renderToNodeStream(
   })
   setTimeout(() => {
     abort()
-    options.onTimeout && options.onTimeout()
+    options.onTimeout?.()
   }, options.timeout ?? DEFAULT_TIMEOUT)
   let promiseResolved = false
   const { pipeForUser, injectToStream, streamEnd } = await createPipeWrapper(pipeOriginal, {

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -15,7 +15,7 @@ async function renderToNodeStream(
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
     streamOptions?: StreamOptions
-    timeout?: number
+    timeout?: number | null
     onTimeout?: () => void
     renderToPipeableStream?: typeof renderToPipeableStream__
   }
@@ -65,10 +65,12 @@ async function renderToNodeStream(
     onShellError: onError,
     onError
   })
-  setTimeout(() => {
-    abort()
-    options.onTimeout?.()
-  }, options.timeout ?? DEFAULT_TIMEOUT)
+  if (options.timeout !== null) {
+    setTimeout(() => {
+      abort()
+      options.onTimeout?.()
+    }, options.timeout ?? DEFAULT_TIMEOUT)
+  }
   let promiseResolved = false
   const { pipeForUser, injectToStream, streamEnd } = await createPipeWrapper(pipeOriginal, {
     onReactBug(err) {

--- a/src/server/renderToStream/renderToNodeStream.ts
+++ b/src/server/renderToStream/renderToNodeStream.ts
@@ -5,7 +5,7 @@ import React from 'react'
 import { renderToPipeableStream as renderToPipeableStream_ } from 'react-dom/server.node'
 import type { renderToPipeableStream as renderToPipeableStream__ } from 'react-dom/server'
 import { createPipeWrapper } from './createPipeWrapper'
-import { afterReactBugCatch, assertReactImport, debugFlow, DEFAULT_TIMEOUT, wrapStreamEnd } from './misc'
+import { afterReactBugCatch, assertReactImport, debugFlow, startTimeout, wrapStreamEnd } from './misc'
 import type { StreamOptions } from '../renderToStream'
 
 async function renderToNodeStream(
@@ -65,16 +65,7 @@ async function renderToNodeStream(
     onShellError: onError,
     onError
   })
-  let stopTimeout: undefined | (() => void)
-  if (options.timeout !== null) {
-    const t = setTimeout(() => {
-      abort()
-      options.onTimeout?.()
-    }, options.timeout ?? DEFAULT_TIMEOUT)
-    stopTimeout = () => {
-      clearTimeout(t)
-    }
-  }
+  const stopTimeout = startTimeout(() => abort(), options)
   let promiseResolved = false
   const { pipeForUser, injectToStream, streamEnd } = await createPipeWrapper(pipeOriginal, {
     stopTimeout,

--- a/src/server/renderToStream/renderToWebStream.ts
+++ b/src/server/renderToStream/renderToWebStream.ts
@@ -5,9 +5,8 @@ import React from 'react'
 import { renderToReadableStream as renderToReadableStream_ } from 'react-dom/server.browser'
 import type { renderToReadableStream as renderToReadableStream__ } from 'react-dom/server'
 import { createReadableWrapper } from './createReadableWrapper'
-import { afterReactBugCatch, assertReactImport, debugFlow, wrapStreamEnd } from './misc'
+import { afterReactBugCatch, assertReactImport, debugFlow, DEFAULT_TIMEOUT, wrapStreamEnd } from './misc'
 import type { StreamOptions } from '../renderToStream'
-import { DEFAULT_TIMEOUT } from './constants'
 
 async function renderToWebStream(
   element: React.ReactNode,
@@ -16,7 +15,7 @@ async function renderToWebStream(
     debug?: boolean
     onBoundaryError?: (err: unknown) => void
     streamOptions?: StreamOptions
-    timeout?: number
+    timeout?: number | null
     onTimeout?: () => void
     renderToReadableStream?: typeof renderToReadableStream__
   }
@@ -26,7 +25,7 @@ async function renderToWebStream(
   const controller: AbortController = new AbortController()
   setTimeout(() => {
     controller?.abort()
-    options.onTimeout && options.onTimeout()
+    options.onTimeout?.()
   }, options.timeout ?? DEFAULT_TIMEOUT)
 
   let didError = false

--- a/src/server/renderToStream/renderToWebStream.ts
+++ b/src/server/renderToStream/renderToWebStream.ts
@@ -23,10 +23,12 @@ async function renderToWebStream(
   debugFlow('creating Web Stream Pipe')
 
   const controller: AbortController = new AbortController()
-  setTimeout(() => {
-    controller?.abort()
-    options.onTimeout?.()
-  }, options.timeout ?? DEFAULT_TIMEOUT)
+  if (options.timeout !== null) {
+    setTimeout(() => {
+      controller?.abort()
+      options.onTimeout?.()
+    }, options.timeout ?? DEFAULT_TIMEOUT)
+  }
 
   let didError = false
   let firstErr: unknown = null


### PR DESCRIPTION
Adding timeout options as per https://react.dev/reference/react-dom/server/renderToReadableStream#aborting-server-rendering and https://react.dev/reference/react-dom/server/renderToPipeableStream#aborting-server-rendering

Follow up of #34.