### PR TITLE
fix: fix race conditions when closing and destroying streams

### DIFF
--- a/src/server/renderToStream/createPipeWrapper.ts
+++ b/src/server/renderToStream/createPipeWrapper.ts
@@ -57,6 +57,7 @@ async function createPipeWrapper(
           debug('final')
           clearTimeouts()
           await onBeforeEnd()
+          // https://github.com/brillout/react-streaming/pull/56
           writableFromUser.end(() => {
             onEnded()
             callback()

--- a/src/server/renderToStream/createPipeWrapper.ts
+++ b/src/server/renderToStream/createPipeWrapper.ts
@@ -57,16 +57,21 @@ async function createPipeWrapper(
           debug('final')
           clearTimeouts()
           await onBeforeEnd()
-          writableFromUser.end()
-          onEnded()
-          callback()
+          writableFromUser.end(() => {
+            onEnded()
+            callback()
+          })
         },
         destroy(err) {
           debug(`destroy (\`!!err === ${!!err}\`)`)
           clearTimeouts()
           // Upon React internal errors (i.e. React bugs), React destroys the stream.
           if (err) onReactBug(err)
-          writableFromUser.destroy(err ?? undefined)
+          // If the user writable has been ended, we don't need to destroy it. Doing so
+          // crashes Node if there's still data being flushed from it.
+          if (!writableFromUser.writableEnded) {
+            writableFromUser.destroy(err ?? undefined)
+          }
           onEnded()
         },
       })


### PR DESCRIPTION
Fixes #55

When injecting a large amount of data right at the end of a streaming render, it's important to make sure that the streams have all their data fully flushed through before cleaning them up. We've been using this patch in production for nearly a year and it's fully solved our `ERR_STREAM_PREMATURE_CLOSE` issues.